### PR TITLE
Fix build

### DIFF
--- a/project/plugins/Plugins.scala
+++ b/project/plugins/Plugins.scala
@@ -4,9 +4,9 @@ class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
   val databinder_repo = "Databinder Repository" at "http://databinder.net/repo"
   val spde_sbt = "us.technically.spde" % "spde-sbt-plugin" % "0.4.2"
 
-  val t_repo = "t_repo" at "http://tristanhunt.com:8081/content/groups/public/"
+  val sonatype_repo = "Sonatype Repo" at "https://oss.sonatype.org/content/repositories/releases"
   val snuggletex_repo = "snuggletex_repo" at "http://www2.ph.ed.ac.uk/maven2"
-  val posterous = "net.databinder" % "posterous-sbt" % "0.1.6"
+  val posterous = "net.databinder" % "posterous-sbt" % "0.1.7"
 
   val android = "org.scala-tools.sbt" % "sbt-android-plugin" % "0.5.0"
 }


### PR DESCRIPTION
- Repository listed for knockoff dependency was no longer available,
  replaced with sonatype repo, where knockoff is now hosted.
- posterous-sbt v0.1.6 depended on a version of knockoff which was
  not in sonatype repo - switched to v0.1.7.
